### PR TITLE
Bug 654355 Multiple Client Match Rules

### DIFF
--- a/apps/homesnippets/models.py
+++ b/apps/homesnippets/models.py
@@ -55,12 +55,18 @@ class ClientMatchRuleManager(models.Manager):
 
         if not cache_hit:
             # Cache miss, so recalculate the results and cache them.
-            matches = [ rule for rule in self._cached_all() 
-                    if rule.is_match(args) ]
-            (include_ids, exclude_ids) = (
-                [str(rule.id) for rule in matches if not rule.exclude],
-                [str(rule.id) for rule in matches if rule.exclude],
-            )
+            rules = self._cached_all()
+            include_ids, exclude_ids = [], []
+
+            for rule in rules:
+                if rule.is_match(args):
+                    if rule.exclude:
+                        exclude_ids.append(str(rule.id))
+                    else:
+                        include_ids.append(str(rule.id))
+                elif not rule.exclude:
+                    exclude_ids.append(str(rule.id))
+
             cache_hit = (mktime(gmtime()), (include_ids, exclude_ids))
             cache.set(cache_key, cache_hit, CACHE_TIMEOUT)
 

--- a/apps/homesnippets/tests/caching.py
+++ b/apps/homesnippets/tests/caching.py
@@ -1,55 +1,45 @@
 """
 homesnippets caching tests
 """
-import logging
 import time
 import random
-import datetime
 
 from django.conf import settings
-
-from django.db import connection
-
-from django.http import HttpRequest
-from django.test import TestCase
-from django.test.client import Client
- 
-from django.core.cache import cache
+from django.core import cache
 from django.core.cache.backends import locmem
 
-from nose.tools import assert_equal, with_setup, assert_false, eq_, ok_
-from nose.plugins.attrib import attr
+from nose.tools import eq_, ok_
 
-from homesnippets.models import Snippet, ClientMatchRule
-from homesnippets.models import CACHE_RULE_MATCH_PREFIX, CACHE_RULE_LASTMOD_PREFIX
-from homesnippets.models import CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX
-from homesnippets.models import CACHE_RULE_NEW_LASTMOD_PREFIX
-from homesnippets.models import CACHE_SNIPPET_LASTMOD_PREFIX
-from homesnippets.models import CACHE_SNIPPET_LOOKUP_PREFIX
-
-import django.core.cache
 import homesnippets.models
-
+from homesnippets.models import (Snippet, ClientMatchRule,
+                                 CACHE_RULE_MATCH_PREFIX,
+                                 CACHE_RULE_LASTMOD_PREFIX,
+                                 CACHE_RULE_ALL_PREFIX,
+                                 CACHE_RULE_ALL_LASTMOD_PREFIX,
+                                 CACHE_RULE_NEW_LASTMOD_PREFIX,
+                                 CACHE_SNIPPET_LASTMOD_PREFIX,
+                                 CACHE_SNIPPET_LOOKUP_PREFIX)
 from homesnippets.tests.utils import HomesnippetsTestCase
+
 
 class CacheClass(locmem.CacheClass):
     """Cache subclass that comes with a hacky event log for test assertions"""
 
     def __init__(self, server, params):
         locmem.CacheClass.__init__(self, server, params)
-        self.id = random.randint(0,1000)
+        self.id = random.randint(0, 1000)
         self.log = []
         self.during_many = False
 
     def get(self, key, default=None):
         if not self.during_many:
             self.log.append(('get', key))
-        return locmem.CacheClass.get(self,key,default)
+        return locmem.CacheClass.get(self, key, default)
 
     def set(self, key, value, timeout=None):
         if not self.during_many:
             self.log.append(('set', key, value))
-        return locmem.CacheClass.set(self,key,value,timeout)
+        return locmem.CacheClass.set(self, key, value, timeout)
 
     def clear(self):
         self.log = []
@@ -58,14 +48,14 @@ class CacheClass(locmem.CacheClass):
     def get_many(self, keys):
         self.log.append(('get_many', keys))
         self.during_many = True
-        rv = locmem.CacheClass.get_many(self,keys)
+        rv = locmem.CacheClass.get_many(self, keys)
         self.during_many = False
         return rv
 
     def set_many(self, keys, timeout):
         self.log.append(('set_many', keys, timeout))
         self.during_many = True
-        rv = locmem.CacheClass.set_many(self,keys,timeout)
+        rv = locmem.CacheClass.set_many(self, keys, timeout)
         self.during_many = False
         return rv
 
@@ -76,58 +66,59 @@ class TestSnippetsCache(HomesnippetsTestCase):
         HomesnippetsTestCase.setUp(self)
 
         settings.CACHE_BACKEND = 'homesnippets.tests://'
-        self.cache = django.core.cache.get_cache(settings.CACHE_BACKEND)
-        django.core.cache.cache = self.cache
+        self.cache = cache.get_cache(settings.CACHE_BACKEND)
+        cache.cache = self.cache
         homesnippets.models.cache = self.cache
         self.cache.clear()
 
         self.rules = self.setup_rules({
-            'fields': ( 'startpage_version', 'name', 'version', 'locale', ),
+            'fields': ('startpage_version', 'name', 'version', 'locale'),
             'items': {
                 # Specific rule, expected to be matched
-                'specific': ( '1', 'Firefox', '4.0', 'en-US', ),
+                'specific': ('1', 'Firefox', '4.0', 'en-US'),
                 # Less-specific rule, should match but not result in duplicate
-                'vague': ( '1', 'Firefox', '4.0', None, ),
+                'vague': ('1', 'Firefox', '4.0', None),
                 # Rule that won't be attached to any snippet.
-                'unused': ( '1', 'Mudfish', '7.0', 'en-GB', ),
+                'unused': ('1', 'Mudfish', '7.0', 'en-GB'),
                 # Rule that will be attached to snippet, but not matched.
-                'unmatched': ( '2', 'Airdog',  '3.0', 'de' ),
+                'unmatched': ('2', 'Airdog',  '3.0', 'de'),
                 # Rule matching anything
-                'all': ( None, None, None, None ),
+                'all': (None, None, None, None),
             }
         })
 
         self.snippets = self.setup_snippets(self.rules, {
-            'fields': ( 'name', 'body', 'rules' ),
+            'fields': ('name', 'body', 'rules'),
             'items': {
                 # Using specific and less-specific rule
-                'expected': ( 'test 1', 'Expected body data', 
-                    ( self.rules['specific'], self.rules['vague'] ) ),
+                'expected': ('test 1', 'Expected body data',
+                             (self.rules['specific'], self.rules['vague'])),
                 # No rules, so always included in results
-                'ever': ( 'test 2', 'Ever-present body data', 
-                    ( self.rules['all'], ) ),
-                # Rule attached that will never be matched, so should never appear
-                'never': (' test 3', 'Never-present body data', 
-                    ( self.rules['unmatched'], ) ),
+                'ever': ('test 2', 'Ever-present body data',
+                         (self.rules['all'], )),
+                # Rule attached that will never be matched,
+                # so should never appear
+                'never': ('test 3', 'Never-present body data',
+                          (self.rules['unmatched'], )),
             }
         })
 
         # Warm up the cache with some initial requests...
         self.assert_snippets({
             '/1/Firefox/4.0/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                ( self.snippets['expected'], True  ), 
-                ( self.snippets['ever'], True  ), 
-                ( self.snippets['never'], False ),
+                (self.snippets['expected'], True),
+                (self.snippets['ever'], True),
+                (self.snippets['never'], False),
             ),
             '/9/Waterduck/9.2/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                ( self.snippets['expected'], False ), 
-                ( self.snippets['ever'], True  ), 
-                ( self.snippets['never'], False ),
+                (self.snippets['expected'], False),
+                (self.snippets['ever'], True),
+                (self.snippets['never'], False),
             ),
             '/1/Mudfish/7.0/xxx/xxx/en-GB/xxx/xxx/default/default/': (
-                ( self.snippets['expected'], False ), 
-                ( self.snippets['ever'], True  ), 
-                ( self.snippets['never'], False ),
+                (self.snippets['expected'], False),
+                (self.snippets['ever'], True),
+                (self.snippets['never'], False),
             ),
         })
 
@@ -136,15 +127,15 @@ class TestSnippetsCache(HomesnippetsTestCase):
         self.assert_cache_events((
 
             # First, the lastmod times for rules are cached
-            ('set_many', [CACHE_RULE_LASTMOD_PREFIX, 
+            ('set_many', [CACHE_RULE_LASTMOD_PREFIX,
                 CACHE_RULE_ALL_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
-            ('set_many', [CACHE_RULE_LASTMOD_PREFIX, 
+            ('set_many', [CACHE_RULE_LASTMOD_PREFIX,
                 CACHE_RULE_ALL_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
-            ('set_many', [CACHE_RULE_LASTMOD_PREFIX, 
+            ('set_many', [CACHE_RULE_LASTMOD_PREFIX,
                 CACHE_RULE_ALL_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
-            ('set_many', [CACHE_RULE_LASTMOD_PREFIX, 
+            ('set_many', [CACHE_RULE_LASTMOD_PREFIX,
                 CACHE_RULE_ALL_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
-            ('set_many', [CACHE_RULE_LASTMOD_PREFIX, 
+            ('set_many', [CACHE_RULE_LASTMOD_PREFIX,
                 CACHE_RULE_ALL_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
 
             # Then, lastmod times for snippets are cached.
@@ -154,7 +145,8 @@ class TestSnippetsCache(HomesnippetsTestCase):
 
             # Request 1
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_ALL_PREFIX,
+                          CACHE_RULE_ALL_LASTMOD_PREFIX]),
             ('set', CACHE_RULE_ALL_PREFIX),
             ('set', CACHE_RULE_MATCH_PREFIX),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
@@ -162,18 +154,20 @@ class TestSnippetsCache(HomesnippetsTestCase):
 
             # Request 2
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_ALL_PREFIX,
+                          CACHE_RULE_ALL_LASTMOD_PREFIX]),
             ('set', CACHE_RULE_MATCH_PREFIX),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
             ('set', CACHE_SNIPPET_LOOKUP_PREFIX),
 
             # Request 3
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_ALL_PREFIX,
+                          CACHE_RULE_ALL_LASTMOD_PREFIX]),
             ('set', CACHE_RULE_MATCH_PREFIX),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
             ('set', CACHE_SNIPPET_LOOKUP_PREFIX),
-            
+
         ))
 
         # Ensure clock ticks before further cache activity
@@ -184,19 +178,19 @@ class TestSnippetsCache(HomesnippetsTestCase):
 
         self.assert_snippets({
             '/1/Firefox/4.0/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                ( self.snippets['expected'], True  ), 
-                ( self.snippets['ever'], True  ), 
-                ( self.snippets['never'], False ),
+                (self.snippets['expected'], True),
+                (self.snippets['ever'], True),
+                (self.snippets['never'], False),
             ),
             '/9/Waterduck/9.2/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                ( self.snippets['expected'], False ), 
-                ( self.snippets['ever'], True  ), 
-                ( self.snippets['never'], False ),
+                (self.snippets['expected'], False),
+                (self.snippets['ever'], True),
+                (self.snippets['never'], False),
             ),
             '/1/Mudfish/7.0/xxx/xxx/en-GB/xxx/xxx/default/default/': (
-                ( self.snippets['expected'], False ), 
-                ( self.snippets['ever'], True  ), 
-                ( self.snippets['never'], False ),
+                (self.snippets['expected'], False),
+                (self.snippets['ever'], True),
+                (self.snippets['never'], False),
             ),
         })
 
@@ -248,28 +242,28 @@ class TestSnippetsCache(HomesnippetsTestCase):
 
         self.assert_snippets({
             '/1/Firefox/4.0/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                ( self.snippets['expected'], True  ), 
-                ( self.snippets['ever'], True  ), 
-                ( self.snippets['never'], False ),
+                (self.snippets['expected'], True),
+                (self.snippets['ever'], True),
+                (self.snippets['never'], False),
             ),
         })
 
         self.assert_cache_events((
 
             # Rule content changed.
-            ('set_many', [ CACHE_RULE_LASTMOD_PREFIX, 
+            ('set_many', [CACHE_RULE_LASTMOD_PREFIX,
                 CACHE_RULE_ALL_LASTMOD_PREFIX]),
-            
+
             # Rule cache miss
             ('get', CACHE_RULE_MATCH_PREFIX),
             ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
-                CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
                           CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
                           CACHE_RULE_LASTMOD_PREFIX,
                           CACHE_RULE_NEW_LASTMOD_PREFIX]),
 
             # All rules cache miss
-            ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_ALL_PREFIX,
+                          CACHE_RULE_ALL_LASTMOD_PREFIX]),
             ('set', CACHE_RULE_ALL_PREFIX),
 
             ('set', CACHE_RULE_MATCH_PREFIX),
@@ -295,16 +289,16 @@ class TestSnippetsCache(HomesnippetsTestCase):
 
         self.assert_snippets({
             '/9/Waterduck/9.2/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                ( self.snippets['expected'], False ), 
-                ( self.snippets['ever'], True  ), 
-                ( self.snippets['never'], False ),
+                (self.snippets['expected'], False),
+                (self.snippets['ever'], True),
+                (self.snippets['never'], False),
             ),
         })
 
         self.assert_cache_events((
 
             # Snippet content changed, bumps rules as well.
-            ('set_many', [CACHE_SNIPPET_LASTMOD_PREFIX, 
+            ('set_many', [CACHE_SNIPPET_LASTMOD_PREFIX,
                 CACHE_RULE_LASTMOD_PREFIX]),
 
             # Rule cache miss
@@ -328,36 +322,39 @@ class TestSnippetsCache(HomesnippetsTestCase):
         ))
 
     def test_invalidation_with_url_variety(self):
-        """Exercise cache with a variety of URLs resulting in the same snippets"""
+        """
+        Exercise cache with a variety of URLs resulting in the same snippets
+        """
 
         # Change a snippet, which should invalidate cached results for snippets
         self.snippets['ever'].body = 'changed_again'
         self.snippets['ever'].save()
 
-        # Try multiple URLs that result in the same set of matching rules, 
+        # Try multiple URLs that result in the same set of matching rules,
         # should cause cache misses in rules, but not in snippet lookup
-        for idx in (0,1):
+        for idx in (0, 1):
             self.assert_snippets({
                 '/1/Alpha/4.0/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                    ( self.snippets['ever'], True  ), 
+                    (self.snippets['ever'], True),
                 ),
                 '/1/Beta/9.2/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                    ( self.snippets['ever'], True  ), 
+                    (self.snippets['ever'], True),
                 ),
                 '/1/Gamma/7.0/xxx/xxx/en-GB/xxx/xxx/default/default/': (
-                    ( self.snippets['ever'], True  ), 
+                    (self.snippets['ever'], True),
                 ),
             })
 
         self.assert_cache_events((
 
             # Content changed
-            ('set_many', [CACHE_SNIPPET_LASTMOD_PREFIX, 
+            ('set_many', [CACHE_SNIPPET_LASTMOD_PREFIX,
                 CACHE_RULE_LASTMOD_PREFIX]),
 
             # Request #1 - cache miss on rules and snippets
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_ALL_PREFIX,
+                          CACHE_RULE_ALL_LASTMOD_PREFIX]),
             ('set', CACHE_RULE_MATCH_PREFIX),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
             ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
@@ -369,7 +366,8 @@ class TestSnippetsCache(HomesnippetsTestCase):
 
             # Request #2 - cache miss on rules, but hit on snippets
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_ALL_PREFIX,
+                          CACHE_RULE_ALL_LASTMOD_PREFIX]),
             ('set', CACHE_RULE_MATCH_PREFIX),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
             ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
@@ -379,7 +377,8 @@ class TestSnippetsCache(HomesnippetsTestCase):
 
             # Request #3 - cache miss on rules, but hit on snippets
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_ALL_PREFIX,
+                          CACHE_RULE_ALL_LASTMOD_PREFIX]),
             ('set', CACHE_RULE_MATCH_PREFIX),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
             ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
@@ -437,7 +436,7 @@ class TestSnippetsCache(HomesnippetsTestCase):
 
         self.assert_snippets({
             '/1/Gamma/7.0/xxx/xxx/en-GB/xxx/xxx/default/default/': (
-                ( new_snippet, True  ), 
+                (new_snippet, True),
             ),
         })
 
@@ -445,19 +444,17 @@ class TestSnippetsCache(HomesnippetsTestCase):
         """Match up a set of expected cache events and prefixes with the cache
         log. Clears the log after a successful assertion set."""
 
-        expected_len = len(expected_events)
-
         expected_events = list(expected_events)
         while expected_events:
             expected = expected_events.pop(0)
-            result   = self.cache.log.pop(0)
+            result = self.cache.log.pop(0)
 
             eq_(expected[0], result[0])
-            
+
             if type(expected[1]) is str:
                 ok_(result[1].startswith(expected[1]),
-                    '%s should start with %s' % (result[1], expected[1] ))
-            
+                    '%s should start with %s' % (result[1], expected[1]))
+
             else:
                 prefixes = expected[1]
                 prefixes.sort()
@@ -470,11 +467,10 @@ class TestSnippetsCache(HomesnippetsTestCase):
                 for idx2 in range(0, len(prefixes)):
                     ok_(result_keys[idx2].startswith(prefixes[idx2]),
                         '%s should start with %s' % (
-                            result_keys[idx2], prefixes[idx2] ))
+                            result_keys[idx2], prefixes[idx2]))
 
         result_len = len(self.cache.log)
         eq_(0, result_len,
             'Cache events should be exhausted, but %s left' % (result_len,))
 
         self.cache.log = []
-

--- a/apps/homesnippets/tests/caching.py
+++ b/apps/homesnippets/tests/caching.py
@@ -205,27 +205,37 @@ class TestSnippetsCache(HomesnippetsTestCase):
 
             # Request 1
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX, 
-                CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_NEW_LASTMOD_PREFIX]),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX, 
-                CACHE_RULE_LASTMOD_PREFIX, CACHE_SNIPPET_LASTMOD_PREFIX, 
-                CACHE_SNIPPET_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX]),
 
             # Request 2
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX, 
-                CACHE_RULE_NEW_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX]),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX, 
-                CACHE_SNIPPET_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_SNIPPET_LASTMOD_PREFIX]),
 
             # Request 3
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, 
-                CACHE_RULE_NEW_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_NEW_LASTMOD_PREFIX]),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_SNIPPET_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_SNIPPET_LASTMOD_PREFIX]),
 
         ))
 
@@ -254,6 +264,9 @@ class TestSnippetsCache(HomesnippetsTestCase):
             ('get', CACHE_RULE_MATCH_PREFIX),
             ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
                 CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_NEW_LASTMOD_PREFIX]),
 
             # All rules cache miss
             ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
@@ -264,8 +277,10 @@ class TestSnippetsCache(HomesnippetsTestCase):
             # Snippet cache miss
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
             ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
-                CACHE_RULE_LASTMOD_PREFIX, CACHE_SNIPPET_LASTMOD_PREFIX,
-                CACHE_SNIPPET_LASTMOD_PREFIX]),
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_SNIPPET_LASTMOD_PREFIX,
+                          CACHE_SNIPPET_LASTMOD_PREFIX]),
 
             ('set', CACHE_SNIPPET_LOOKUP_PREFIX),
 
@@ -294,13 +309,20 @@ class TestSnippetsCache(HomesnippetsTestCase):
 
             # Rule cache miss
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
-            ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_NEW_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_ALL_PREFIX,
+                          CACHE_RULE_ALL_LASTMOD_PREFIX]),
             ('set', CACHE_RULE_MATCH_PREFIX),
-            
+
             # Snippet cache miss
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_SNIPPET_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_SNIPPET_LASTMOD_PREFIX]),
             ('set', CACHE_SNIPPET_LOOKUP_PREFIX),
 
         ))
@@ -338,7 +360,10 @@ class TestSnippetsCache(HomesnippetsTestCase):
             ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
             ('set', CACHE_RULE_MATCH_PREFIX),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_SNIPPET_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_SNIPPET_LASTMOD_PREFIX]),
             # Snippets looked up & cached for this request only
             ('set', CACHE_SNIPPET_LOOKUP_PREFIX),
 
@@ -347,32 +372,56 @@ class TestSnippetsCache(HomesnippetsTestCase):
             ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
             ('set', CACHE_RULE_MATCH_PREFIX),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_SNIPPET_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_SNIPPET_LASTMOD_PREFIX]),
 
             # Request #3 - cache miss on rules, but hit on snippets
             ('get', CACHE_RULE_MATCH_PREFIX),
             ('get_many', [CACHE_RULE_ALL_PREFIX, CACHE_RULE_ALL_LASTMOD_PREFIX]),
             ('set', CACHE_RULE_MATCH_PREFIX),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_SNIPPET_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_SNIPPET_LASTMOD_PREFIX]),
 
             # Request #4 - cache hits, all around
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_NEW_LASTMOD_PREFIX]),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_SNIPPET_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_SNIPPET_LASTMOD_PREFIX]),
 
             # Request #5 - cache hits, all around
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_NEW_LASTMOD_PREFIX]),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_SNIPPET_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_SNIPPET_LASTMOD_PREFIX]),
 
             # Request #6 - cache hits, all around
             ('get', CACHE_RULE_MATCH_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_NEW_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_NEW_LASTMOD_PREFIX]),
             ('get', CACHE_SNIPPET_LOOKUP_PREFIX),
-            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_SNIPPET_LASTMOD_PREFIX]),
+            ('get_many', [CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX, CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_RULE_LASTMOD_PREFIX,
+                          CACHE_SNIPPET_LASTMOD_PREFIX]),
 
         ))
 

--- a/apps/homesnippets/tests/rules.py
+++ b/apps/homesnippets/tests/rules.py
@@ -224,7 +224,10 @@ class TestSnippetsMatch(HomesnippetsTestCase):
         })
 
     def test_unmatched_inclusion_rules(self):
-        """Exercise inclusion rules that don't match"""
+        """
+        Test to ensure that if an inclusion rule does not match, the associated
+        snippet is not sent.
+        """
 
         rules = self.setup_rules({
             'fields': ('name', 'version', 'exclude'),

--- a/apps/homesnippets/tests/rules.py
+++ b/apps/homesnippets/tests/rules.py
@@ -1,30 +1,13 @@
 """
 homesnippets client match rule tests
 """
-import logging
-import time
-import random
 import datetime
 
-from django.conf import settings
+from nose.tools import eq_
 
-from django.db import connection
-
-from django.http import HttpRequest
-from django.test import TestCase
-from django.test.client import Client
- 
-from django.core.cache import cache
-from django.core.cache.backends import locmem
-
-from nose.tools import assert_equal, with_setup, assert_false, eq_, ok_
-from nose.plugins.attrib import attr
-
-from homesnippets.models import Snippet, ClientMatchRule
-
-import homesnippets.models
-
+from homesnippets.models import Snippet
 from homesnippets.tests.utils import HomesnippetsTestCase
+
 
 class TestSnippetsMatch(HomesnippetsTestCase):
     """Exercise selection of snippets via client match rules"""
@@ -33,51 +16,52 @@ class TestSnippetsMatch(HomesnippetsTestCase):
         """Exercise simple exact match rules"""
 
         rules = self.setup_rules({
-            'fields': ( 'startpage_version', 'name', 'version', 'locale', ),
+            'fields': ('startpage_version', 'name', 'version', 'locale'),
             'items': {
                 # Specific rule, expected to be matched
-                'specific': ( '1', 'Firefox', '4.0', 'en-US', ),
+                'specific': ('1', 'Firefox', '4.0', 'en-US'),
                 # Less-specific rule, should match but not result in duplicate
-                'vague': ( '1', 'Firefox', '4.0', None, ),
+                'vague': ('1', 'Firefox', '4.0', None),
                 # Rule that won't be attached to any snippet.
-                'unused': ( '1', 'Mudfish', '7.0', 'en-GB', ),
+                'unused': ('1', 'Mudfish', '7.0', 'en-GB'),
                 # Rule that will be attached to snippet, but not matched.
-                'unmatched': ( '2', 'Airdog',  '3.0', 'de' ),
+                'unmatched': ('2', 'Airdog',  '3.0', 'de'),
                 # Rule matching anything
-                'all': ( None, None, None, None ),
+                'all': (None, None, None, None),
             }
         })
 
         snippets = self.setup_snippets(rules, {
-            'fields': ( 'name', 'body', 'rules' ),
+            'fields': ('name', 'body', 'rules'),
             'items': {
                 # Using specific and less-specific rule
-                'expected': ( 'test 1', 'Expected body data', 
-                    ( rules['specific'], rules['vague'] ) ),
+                'expected': ('test 1', 'Expected body data',
+                    (rules['specific'], rules['vague'])),
                 # No rules, so always included in results
-                'ever': ( 'test 2', 'Ever-present body data', 
-                    ( rules['all'], ) ),
-                # Rule attached that will never be matched, so should never appear
-                'never': (' test 3', 'Never-present body data', 
-                    ( rules['unmatched'], ) ),
+                'ever': ('test 2', 'Ever-present body data',
+                    (rules['all'],)),
+                # Rule attached that will never be matched,
+                # so should never appear
+                'never': ('test 3', 'Never-present body data',
+                    (rules['unmatched'],)),
             }
         })
 
         self.assert_snippets({
             '/1/Firefox/4.0/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                ( snippets['expected'], True  ), 
-                ( snippets['ever'], True  ), 
-                ( snippets['never'], False ),
+                (snippets['expected'], True),
+                (snippets['ever'], True),
+                (snippets['never'], False),
             ),
             '/9/Waterduck/9.2/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                ( snippets['expected'], False ), 
-                ( snippets['ever'], True  ), 
-                ( snippets['never'], False ),
+                (snippets['expected'], False),
+                (snippets['ever'], True),
+                (snippets['never'], False),
             ),
             '/1/Mudfish/7.0/xxx/xxx/en-GB/xxx/xxx/default/default/': (
-                ( snippets['expected'], False ), 
-                ( snippets['ever'], True  ), 
-                ( snippets['never'], False ),
+                (snippets['expected'], False),
+                (snippets['ever'], True),
+                (snippets['never'], False),
             ),
         })
 
@@ -85,49 +69,50 @@ class TestSnippetsMatch(HomesnippetsTestCase):
         """Exercise match rules that exclude snippets"""
 
         rules = self.setup_rules({
-            'fields': ( 'startpage_version', 'name', 'version', 'locale', 'exclude' ),
+            'fields': ('startpage_version', 'name', 'version', 'locale',
+                       'exclude'),
             'items': {
-                'specific': ( '1', 'Firefox', '4.0', 'en-US', True, ),
-                'vague': ( '1', 'Firefox', '4.0', None, False, ),
-                'mudfish': ( '1', 'Mudfish', '7.0', 'en-GB', True, ),
-                'airdog': ( '2', 'Airdog',  '3.0', 'de', False, ),
-                'nowindcat': ( '1', 'Windcat', '9.3', 'fr', True ),
-                'all': ( None, None, None, None, False ),
+                'specific': ('1', 'Firefox', '4.0', 'en-US', True),
+                'vague': ('1', 'Firefox', '4.0', None, False),
+                'mudfish': ('1', 'Mudfish', '7.0', 'en-GB', True),
+                'airdog': ('2', 'Airdog',  '3.0', 'de', False),
+                'nowindcat': ('1', 'Windcat', '9.3', 'fr', True),
+                'all': (None, None, None, None, False),
             }
         })
 
         snippets = self.setup_snippets(rules, {
-            'fields': ( 'name', 'body', 'rules' ),
+            'fields': ('name', 'body', 'rules'),
             'items': {
-                'en-GB': ( 'test 1', 'Expected in en-GB but not en-US', 
-                    ( rules['specific'], rules['vague'] ) ),
-                'ever': ( 'test 2', 'Ever-present body data', 
-                    ( rules['all'], ) ),
-                'never': (' test 3', 'Never-present body data', 
-                    ( rules['airdog'], ) ),
-                'usually': ( 'test 4', 'Usually-present body data', 
-                    ( rules['all'], rules['nowindcat'], ) ),
+                'en-GB': ('test 1', 'Expected in en-GB but not en-US',
+                    (rules['specific'], rules['vague'])),
+                'ever': ('test 2', 'Ever-present body data',
+                    (rules['all'],)),
+                'never': (' test 3', 'Never-present body data',
+                    (rules['airdog'],)),
+                'usually': ('test 4', 'Usually-present body data',
+                    (rules['all'], rules['nowindcat'])),
             }
         })
 
         self.assert_snippets({
             '/1/Firefox/4.0/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                ( snippets['en-GB'], False ), 
-                ( snippets['ever'], True  ), 
-                ( snippets['never'], False ), 
-                ( snippets['usually'], True  ),
+                (snippets['en-GB'], False),
+                (snippets['ever'], True),
+                (snippets['never'], False),
+                (snippets['usually'], True),
             ),
             '/1/Firefox/4.0/xxx/xxx/en-GB/xxx/xxx/default/default/': (
-                ( snippets['en-GB'], True  ), 
-                ( snippets['ever'], True  ), 
-                ( snippets['never'], False ), 
-                ( snippets['usually'], True  ),
+                (snippets['en-GB'], True),
+                (snippets['ever'], True),
+                (snippets['never'], False),
+                (snippets['usually'], True),
             ),
             '/1/Windcat/9.3/xxx/xxx/fr/xxx/xxx/default/default/': (
-                ( snippets['en-GB'], False ), 
-                ( snippets['ever'], True  ), 
-                ( snippets['never'], False ), 
-                ( snippets['usually'], False ),
+                (snippets['en-GB'], False),
+                (snippets['ever'], True),
+                (snippets['never'], False),
+                (snippets['usually'], False),
             ),
         })
 
@@ -135,26 +120,26 @@ class TestSnippetsMatch(HomesnippetsTestCase):
         """Exercise omission of disabled snippets"""
 
         rules = self.setup_rules({
-            'fields': ( 'exclude', ),
+            'fields': ('exclude',),
             'items': {
-                'all': ( False, ),
+                'all': (False,),
             }
         })
 
         snippets = self.setup_snippets(rules, {
-            'fields': ( 'name', 'body', 'disabled', 'rules' ),
+            'fields': ('name', 'body', 'disabled', 'rules'),
             'items': {
-                'shown_1':  ( 'one',   'Shown 1',  False, ( rules['all'], ) ),
-                'disabled': ( 'two',   'Disabled', True,  ( rules['all'], ) ),
-                'shown_2':  ( 'three', 'Shown 2',  False, ( rules['all'], ) ),
+                'shown_1':  ('one', 'Shown 1', False, (rules['all'],)),
+                'disabled': ('two', 'Disabled', True,  (rules['all'],)),
+                'shown_2':  ('three', 'Shown 2', False, (rules['all'],)),
             }
         })
 
         self.assert_snippets({
             '/1/Firefox/4.0/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                ( snippets['shown_1'],  True ), 
-                ( snippets['shown_2'],  True ), 
-                ( snippets['disabled'], False ), 
+                (snippets['shown_1'], True),
+                (snippets['shown_2'], True),
+                (snippets['disabled'], False),
             ),
         })
 
@@ -162,82 +147,79 @@ class TestSnippetsMatch(HomesnippetsTestCase):
         """Exercise start/end publication dates"""
 
         rules = self.setup_rules({
-            'fields': ( 'exclude', ),
+            'fields': ('exclude',),
             'items': {
-                'all': ( False, ),
+                'all': (False,),
             }
         })
 
-        snippets = self.setup_snippets(rules, {
-            'fields': ( 'body', 'rules', 'pub_start', 'pub_end', ),
+        self.setup_snippets(rules, {
+            'fields': ('body', 'rules', 'pub_start', 'pub_end'),
             'items': {
-                'shown_1':  ( 'Shown 1', ( rules['all'],),
-                    None, 
-                    None, ),
-                'shown_2':  ( 'Shown 2', ( rules['all'],), 
-                    datetime.datetime(2010, 10, 25), 
-                    None, ),
-                'shown_3':  ( 'Shown 3', ( rules['all'],), 
-                    None, 
-                    datetime.datetime(2010, 12, 24), ),
-                'shown_4':  ( 'Shown 4', ( rules['all'],), 
-                    datetime.datetime(2010, 10, 24), 
-                    datetime.datetime(2010, 10, 31), ),
+                'shown_1': ('Shown 1', (rules['all'],), None, None),
+                'shown_2': ('Shown 2', (rules['all'],),
+                            datetime.datetime(2010, 10, 25), None),
+                'shown_3': ('Shown 3', (rules['all'],), None,
+                            datetime.datetime(2010, 12, 24)),
+                'shown_4': ('Shown 4', (rules['all'],),
+                            datetime.datetime(2010, 10, 24),
+                            datetime.datetime(2010, 10, 31)),
             }
         })
 
         expected = [
-            ( datetime.datetime(2010, 10, 01), 
-                ( 'shown_1', 'shown_3', ) ),
-            ( datetime.datetime(2010, 10, 25), 
-                ( 'shown_1', 'shown_2', 'shown_3', 'shown_4', ) ),
-            ( datetime.datetime(2010, 12, 24), 
-                ( 'shown_1', 'shown_2', 'shown_2', ) ),
-            ( datetime.datetime(2011, 01, 01), 
-                ( 'shown_1', 'shown_2', ) ),
+            (datetime.datetime(2010, 10, 01), ('shown_1', 'shown_3')),
+            (datetime.datetime(2010, 10, 25), ('shown_1', 'shown_2',
+                                               'shown_3', 'shown_4')),
+            (datetime.datetime(2010, 12, 24), ('shown_1', 'shown_2',
+                                               'shown_2')),
+            (datetime.datetime(2011, 01, 01), ('shown_1', 'shown_2')),
         ]
 
         for tm, snippet_names in expected:
             expected_names = set(snippet_names)
-            result_names = set(s['name'] 
-                for s in Snippet.objects.find_snippets_with_match_rules({}, tm))
+            result_names = set(s['name'] for s in
+                Snippet.objects.find_snippets_with_match_rules({}, tm))
             eq_(expected_names, result_names)
 
     def test_regex_rules(self):
         """Exercise match rules that use regexes"""
 
         rules = self.setup_rules({
-            'fields': ( 'startpage_version', 'name', 'version', 'locale', 'exclude' ),
+            'fields': ('startpage_version', 'name', 'version', 'locale',
+                       'exclude'),
             'items': {
-                'fire_or_mud': ( '1', '/(Firefox|Mudfish)/', '4.0', None, False, ),
-                'no_fr_or_de': ( '1', None, '4.0', '/(de|fr)/', True, ),
-                'all': ( None, None, None, None, False ),
+                'fire_or_mud': ('1', '/(Firefox|Mudfish)/', '4.0', None,
+                                False),
+                'no_fr_or_de': ('1', None, '4.0', '/(de|fr)/', True),
+                'all': (None, None, None, None, False),
             }
         })
 
         snippets = self.setup_snippets(rules, {
-            'fields': ( 'name', 'body', 'rules' ),
+            'fields': ('name', 'body', 'rules'),
             'items': {
-                'fire_or_mud': ( 'Fire or Mud', 'Firefox or Mudfish but not Airdog', 
-                    ( rules['fire_or_mud'], rules['no_fr_or_de'], ) ),
+                'fire_or_mud': ('Fire or Mud',
+                                'Firefox or Mudfish but not Airdog',
+                                (rules['fire_or_mud'], rules['no_fr_or_de']))
             }
         })
 
         self.assert_snippets({
             '/1/Firefox/4.0/xxx/xxx/en-US/xxx/xxx/default/default/': (
-                ( snippets['fire_or_mud'], True ), 
+                (snippets['fire_or_mud'], True),
             ),
             '/1/Mudfish/4.0/xxx/xxx/en-GB/xxx/xxx/default/default/': (
-                ( snippets['fire_or_mud'], True  ), 
+                (snippets['fire_or_mud'], True),
             ),
             '/1/Firefox/4.0/xxx/xxx/de/xxx/xxx/default/default/': (
-                ( snippets['fire_or_mud'], False  ), 
+                (snippets['fire_or_mud'], False),
             ),
             '/1/Mudfish/4.0/xxx/xxx/fr/xxx/xxx/default/default/': (
-                ( snippets['fire_or_mud'], False  ), 
+                (snippets['fire_or_mud'], False),
             ),
             '/1/Airdog/4.0/xxx/xxx/en-GB/xxx/xxx/default/default/': (
-                ( snippets['fire_or_mud'], False ), 
+                (snippets['fire_or_mud'], False),
             ),
         })
 

--- a/apps/homesnippets/tests/rules.py
+++ b/apps/homesnippets/tests/rules.py
@@ -241,3 +241,41 @@ class TestSnippetsMatch(HomesnippetsTestCase):
             ),
         })
 
+    def test_unmatched_inclusion_rules(self):
+        """Exercise inclusion rules that don't match"""
+
+        rules = self.setup_rules({
+            'fields': ('name', 'version', 'exclude'),
+            'items': {
+                'firefox': ('Firefox', None, False),
+                '4.0': (None, '4.0', False),
+            }
+        })
+
+        snippets = self.setup_snippets(rules, {
+            'fields': ('name', 'body', 'rules'),
+            'items': {
+                'fire_4.0': ('Firefox 4.0', 'Firefox and 4.0',
+                             (rules['firefox'], rules['4.0'])),
+                'fire': ('Firefox', 'Firefox but not 4.0', (rules['firefox'],)),
+                '4.0': ('4.0', '4.0 but not Firefox', (rules['4.0'],)),
+            }
+        })
+
+        self.assert_snippets({
+            '/1/Firefox/4.0/xxx/xxx/en-US/xxx/xxx/default/default/': (
+                (snippets['fire_4.0'], True),
+                (snippets['fire'], True),
+                (snippets['4.0'], True),
+            ),
+            '/1/Firefox/3.0/xxx/xxx/en-US/xxx/xxx/default/default/': (
+                (snippets['fire_4.0'], False),
+                (snippets['fire'], True),
+                (snippets['4.0'], False),
+            ),
+            '/1/Mudfish/4.0/xxx/xxx/en-US/xxx/xxx/default/default/': (
+                (snippets['fire_4.0'], False),
+                (snippets['fire'], False),
+                (snippets['4.0'], True),
+            ),
+        })

--- a/apps/homesnippets/tests/utils.py
+++ b/apps/homesnippets/tests/utils.py
@@ -1,23 +1,15 @@
 """homesnippets common test utils"""
 import logging
-import time
-import random
-import datetime
 
 from django.conf import settings
-
-from django.http import HttpRequest
 from django.test import TestCase
 from django.test.client import Client
 
-from django.core.cache import cache
-from django.core.cache.backends import locmem
+from nose.tools import eq_
 
 import homesnippets
 from homesnippets.models import Snippet, ClientMatchRule
 
-from nose.tools import assert_equal, with_setup, assert_false, eq_, ok_
-from nose.plugins.attrib import attr
 
 class HomesnippetsTestCase(TestCase):
 
@@ -29,19 +21,16 @@ class HomesnippetsTestCase(TestCase):
 
         ClientMatchRule.objects.all().delete()
         Snippet.objects.all().delete()
-        
+
         homesnippets.models.cache.clear()
 
-    def tearDown(self):
-        from django.db import connection
-        #logging.debug(connection.queries)
-
     def setup_rules(self, rules_data):
-        """Given a data structure defining client match rules, create the 
+        """Given a data structure defining client match rules, create the
         model items"""
         rules = {}
         for name, item in rules_data['items'].items():
-            rules[name] = ClientMatchRule(**dict(zip(rules_data['fields'], item)))
+            rules[name] = ClientMatchRule(**dict(zip(rules_data['fields'],
+                                                     item)))
             rules[name].save()
         return rules
 
@@ -49,7 +38,7 @@ class HomesnippetsTestCase(TestCase):
         """Given a data structure defining snippets, create the model items"""
         snippets = {}
         for name, item_data in snippets_data['items'].items():
-            
+
             item = dict(zip(snippets_data['fields'], item_data))
             if not 'name' in item:
                 item['name'] = name
@@ -75,4 +64,3 @@ class HomesnippetsTestCase(TestCase):
                 eq_(resp.content.count(e_content), e_present and 1 or 0,
                     'Snippet "%s" should%sappear in content for %s' % (
                         e_content, e_present and ' ' or ' not ', path))
-


### PR DESCRIPTION
Changes client match rules such that any inclusion rule that doesn't match a client causes the associated snippet to not be sent to the client. 

This lets us scale by using a small set of rules and composing them together on snippets to limit which clients get which snippets.
