### PR TITLE
Add <div> around all snippets with their snippet ID

### DIFF
--- a/apps/homesnippets/views.py
+++ b/apps/homesnippets/views.py
@@ -51,7 +51,8 @@ def view_snippets(request, **kwargs):
     if len(snippets) == 0:
         out_txt = ''
     else:
-        out = [snippet['body'] for snippet in snippets]
+        out = ['<div data-snippet-id="%s">%s</div>' %
+               (snippet['id'], snippet['body']) for snippet in snippets]
 
         out.append('<!-- content generated at %s -->' %
             (strftime('%Y-%m-%dT%H:%M:%SZ', gmtime())))


### PR DESCRIPTION
In order to write JS that automatically tracks snippet impressions, we need a way to get the ID of a snippet via JS. This surrounding div lets us grab the ID and send that off to the impressions service when the snippet is viewed.

Tested on the new and old about:home page, this extra div does not affect how snippets appear visually.
